### PR TITLE
itree: minor bugfixes

### DIFF
--- a/pancake/semantics/panItreeSemScript.sml
+++ b/pancake/semantics/panItreeSemScript.sml
@@ -13,15 +13,11 @@ local open alignmentTheory
 val _ = new_theory "panItreeSem";
 
 (* Extension of itreeTauTheory *)
-val _ = temp_set_fixity "\226\139\134" (Infixl 500);
-Overload "\226\139\134" = “itree_bind”;
+val _ = temp_set_fixity "⋆" (Infixl 500);
+Overload "⋆" = “itree_bind”;
 
 val _ = temp_set_fixity "≈" (Infixl 500);
 Overload "≈" = “itree_wbisim”;
-
-Definition itree_trigger_def:
-  itree_trigger event = Vis event Ret
-End
 
 Definition itree_mrec_def:
   itree_mrec rh seed =
@@ -126,7 +122,7 @@ End
 Definition h_prog_rule_seq_def:
   h_prog_rule_seq p1 p2 s = Vis (INL (p1,s))
                                 (λ(res,s'). if res = NONE
-                                            then itree_trigger (INL (p2,s'))
+                                            then Vis (INL (p2,s')) Ret
                                             else Ret (res,s'))
 End
 

--- a/pancake/semantics/panItreeSemScript.sml
+++ b/pancake/semantics/panItreeSemScript.sml
@@ -50,17 +50,6 @@ Proof
   rw [Once itreeTauTheory.itree_unfold]
 QED
 
-Theorem itree_mrec_recurse_once[simp]:
-  (h s) = Vis (INL seed') k ⇔
-  itree_mrec h s = Tau (itree_mrec (λs. itree_bind (h s) k) seed')
-Proof
-  rw [itree_mrec_def] >>
-  rw [itreeTauTheory.itree_iter_def] >>
-  rw [Once itreeTauTheory.itree_unfold] >>
-  (* needs proof that k' = k and then itree_bind_right_identity *)
-  cheat
-QED
-
 (* mrec theory *)
 
 (* Show that mrec Vis (INL) nodes are equivalent to one step of general recursion *)
@@ -186,10 +175,10 @@ End
  termination of the loop; when the guard is false. *)
 Definition h_prog_rule_while_def:
   h_prog_rule_while g p s = itree_iter
-                               (λseed. case (eval s g) of
+                               (λ(p,s).case (eval s g) of
                                         | SOME (ValWord w) =>
                                            if (w ≠ 0w)
-                                           then (Vis (INL seed)
+                                           then (Vis (INL (p,s))
                                                  (λ(res,s'). case res of
                                                               | SOME Break => Ret (INR (NONE,s'))
                                                               | SOME Continue => Ret (INL (p,s'))

--- a/pancake/semantics/panItreeSemScript.sml
+++ b/pancake/semantics/panItreeSemScript.sml
@@ -246,9 +246,9 @@ Definition h_prog_rule_ext_call_def:
                    (λres. case res of
                             FFI_final outcome => Ret (SOME (FinalFFI outcome),empty_locals s)
                            | FFI_return new_ffi new_bytes =>
-                              let nmem = write_bytearray array_ptr_adr new_bytes s.memory s.memaddrs s.be in
-                              Ret (NONE,s with <| memory := nmem; ffi := new_ffi |>)
-                              | _ => Ret (SOME Error,s)))) Ret
+                              (let nmem = write_bytearray array_ptr_adr new_bytes s.memory s.memaddrs s.be in
+                                 Ret (NONE,s with <| memory := nmem; ffi := new_ffi |>))
+                           | _ => Ret (SOME Error,s)))) Ret
        | _ => Ret (SOME Error,s))
    | _ => Ret (SOME Error,s)
 End

--- a/pancake/semantics/panItreeSemScript.sml
+++ b/pancake/semantics/panItreeSemScript.sml
@@ -245,7 +245,7 @@ val mtree_ans = “:γ result option # ('a,'b) state”;
 
 Definition h_prog_rule_ext_call_def:
   h_prog_rule_ext_call ffi_name conf_ptr conf_len array_ptr array_len ^s =
-  case (eval s conf_ptr,eval s conf_len,eval s array_ptr,eval s array_len) of
+  case (eval s conf_len,eval s conf_ptr,eval s array_len,eval s array_ptr) of
     (SOME (ValWord conf_sz),SOME (ValWord conf_ptr_adr),
      SOME (ValWord array_sz),SOME (ValWord array_ptr_adr)) =>
      (case (read_bytearray conf_sz (w2n conf_ptr_adr) (mem_load_byte s.memory s.memaddrs s.be),


### PR DESCRIPTION
- remove cheated simp
- bind current state in mrec While case, otherwise the conditional is evaluated only once in the initial state before the loop

there's also a major bug with massage which I am unsure how to fix